### PR TITLE
修复上传时的 json 错误 (#40), 并添加了目录上传功能.

### DIFF
--- a/onedrivecmd/utils/uploader.py
+++ b/onedrivecmd/utils/uploader.py
@@ -7,6 +7,7 @@
 import json
 from progress.bar import Bar
 import requests
+from collections import OrderedDict
 
 try:
     from static import *
@@ -62,9 +63,9 @@ def upload_self(api_base_url = '', token = '', source_file = '', dest_path = '',
     if not dest_path.endswith('/'):
         dest_path += '/'
 
-    # Prepare API call
+    # Prepare API call (note: info_json must be ordered else error 'Annotations must be specified before other elements in a JSON object' will be reported.)
     dest_path = path_to_remote_path(dest_path) + '/' + path_to_name(source_file)
-    info_json = json.dumps({'item': {'@name.conflictBehavior': 'rename', 'name': path_to_name(source_file)}})
+    info_json = json.dumps({'item': OrderedDict([('@name.conflictBehavior', 'rename'), ('name', path_to_name(source_file))])})
 
     api_url = api_base_url + 'drive/root:{dest_path}:/upload.createSession'.format(dest_path = dest_path)
 


### PR DESCRIPTION
`onedrivecmd\utils\uploader.py` 的函数 `upload_self(...)` 中的 `info_json` 是有顺序要求的, 即备注 `@name.conflictBehavior` 得在文件名前. 直接使用字典无法保证顺序, 所以改用了 `collections.OrderedDict`. 