### PR TITLE
bug fix: token may expire while uploading a directory

### DIFF
--- a/onedrivecmd/utils/actions.py
+++ b/onedrivecmd/utils/actions.py
@@ -392,8 +392,7 @@ def do_put(client, args):
 
         # Home brew one, with progress bar
         else:
-            upload_self(api_base_url = client.base_url,
-                        token = get_access_token(client),
+            upload_self(client=client,
                         source_file = i,
                         dest_path = target_dir,
                         chunksize = int(args.chunk))

--- a/onedrivecmd/utils/session.py
+++ b/onedrivecmd/utils/session.py
@@ -40,6 +40,14 @@ def refresh_token(client):
     client.auth_provider.refresh_token()
     return
 
+def token_time_to_live(client):
+    """OneDriveClient->int
+    
+    Get the expiration time of token in sec. 
+    
+    We have to make sure the token is available. 
+    """
+    return int(client.auth_provider._session._expires_at - time())
 
 ## Make our own even worse Session
 


### PR DESCRIPTION
token 默认在 60 分钟内过期, 上传文件夹时 60 分钟之后仍未开始上传的文件就无法上传了. 因此在每次上传文件前检查 token 的剩余存活时间, 如果其小于 50 分钟就刷新之. 既能保证 token 不会过期, 也能保证在上传大量小文件时不会频繁地刷新 token. 
为了在递归过程中检查并刷新 token, 改变了 `upload_self(...)` 的参数表. 