### PR TITLE
V0.1.7: experimental retry-when-failed function; make 'put -hack' recursive; fix bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Since the recent update of Onedrive's API, there aren't a lot of *nix softwares 
   - Ability to access files and folders using a path URI
   - Configuration file (~/.onedrive.json)
   - Individual file get operations
-  - folder/file put operations, and retry when failed (experimental)
+  - Folder/file put operations, and retry when failed (experimental)
   - List operation (shows file size and timestamp)
   - Download and upload with native progress bar (with option of downloading with aria2!)
   - Remote download links to your drive(NEW! Not even available via Web console) (Only available at personal due to API limit)

--- a/onedrivecmd/utils/actions.py
+++ b/onedrivecmd/utils/actions.py
@@ -392,8 +392,7 @@ def do_put(client, args):
 
         # Home brew one, with progress bar
         else:
-            upload_self(api_base_url = client.base_url,
-                        token = get_access_token(client),
+            upload_self(client=client,
                         source_file = i,
                         dest_path = target_dir,
                         chunksize = int(args.chunk))

--- a/onedrivecmd/utils/actions.py
+++ b/onedrivecmd/utils/actions.py
@@ -5,6 +5,7 @@
 # Created: 09/24/2016
 
 from __future__ import unicode_literals
+from collections import OrderedDict
 
 try:
     from static import *
@@ -200,6 +201,10 @@ def do_get(client, args):
             # This is slower then I thought.
             r = requests.get(item_info[0], stream = True)
 
+            if r.status_code > 201:
+                print("\033[31mRequest error:\033[0m "+r.json()['error']['message'])
+                return None
+
             total_length = int(r.headers.get('content-length'))
 
             # this will affect the download speed, but too large will result in progress bar update frequency too low
@@ -292,6 +297,9 @@ def do_direct(client, args):
         if '1drv.ms' in permission.link.web_url:  # personal
             # link like: https://1drv.ms/u/s!blahblah
             req = requests.get(permission.link.web_url, allow_redirects = False)
+            if req.status_code > 201:
+                print("\033[31mRequest error:\033[0m "+req.json()['error']['message'])
+                return None
             # link become: https://onedrive.live.com/redir?resid=xxx!111&authkey=!xxx
             print(req.headers['Location'].replace('redir?', 'download?'))
 
@@ -422,6 +430,9 @@ def do_delete(client, args):
             req = requests.delete(api_base_url + 'drive/items/{id}'.format(id = f.id),
                                   headers = {'Authorization': 'bearer {access_token}'.format(
                                       access_token = get_access_token(client)), })
+            if req.status_code > 201:
+                print("\033[31mRequest error:\033[0m "+req.json()['error']['message'])
+                return None
 
     return client
 
@@ -451,13 +462,17 @@ def do_mkdir(client, args):
                                'Content-Type': 'application/json',
                                'Prefer': 'respond-async', })
 
+        if req.status_code > 201:
+            print("\033[31mRequest error:\033[0m "+req.json()['error']['message'])
+            return None
+
         req = convert_utf8_dict_to_dict(req.json())
         parent_id = req['id']
 
-        data = {
-            "name": path_to_name(folder_path),
-            "folder": {}
-        }
+        data = OrderedDict([
+            ("name", path_to_name(folder_path)),
+            ("folder", {})
+        ])
 
         req = requests.post(client.base_url + '/drive/items/{parent_id}/children'.format(parent_id = parent_id),
                             headers = {'Authorization': 'bearer {access_token}'.format(
@@ -465,6 +480,10 @@ def do_mkdir(client, args):
                                 'Content-Type': 'application/json',
                                 'Prefer': 'respond-async', },
                             json = data)
+
+        if req.status_code > 201:
+            print("\033[31mRequest error:\033[0m "+req.json()['error']['message'])
+            return None
 
         req = convert_utf8_dict_to_dict(req.json())
 
@@ -518,7 +537,7 @@ def do_remote(client, args):
     for i in args.rest:
         # There is no guarantee that this shall be normal, JUST like
         # all the similar services
-        json_data = {'@content.sourceUrl': i, 'file': {}, 'name': path_to_name(i)}
+        json_data = OrderedDict([('@content.sourceUrl', i), ('file', {}), ('name', path_to_name(i))])
 
         root = client.item(drive = 'me', id = 'root').get()
         parent_id = root.id
@@ -529,7 +548,9 @@ def do_remote(client, args):
                                 access_token = get_access_token(client)),
                                 'Content-Type': 'application/json',
                                 'Prefer': 'respond-async', })
-
+        if req.status_code > 201:
+            print("\033[31mRequest error:\033[0m "+req.json()['error']['message'])
+            return None
         print(req.headers['location'])
 
     return client
@@ -553,7 +574,9 @@ def do_quota(client, args):
                        headers = {
                            'Authorization': 'bearer {access_token}'.format(access_token = get_access_token(client)),
                            'content-type': 'application/json'})
-
+    if req.status_code > 201:
+        print("\033[31mRequest error:\033[0m "+req.json()['error']['message'])
+        return None
     print('''
     Total Size: {total},
     Used: {used},

--- a/onedrivecmd/utils/session.py
+++ b/onedrivecmd/utils/session.py
@@ -40,6 +40,14 @@ def refresh_token(client):
     client.auth_provider.refresh_token()
     return
 
+def token_time_to_live(client):
+    """OneDriveClient->int
+    
+    Get the expiration time of token in sec. 
+    
+    We have to make sure the token is available. 
+    """
+    return int(client.auth_provider._session._expires_at - time())
 
 ## Make our own even worse Session
 

--- a/onedrivecmd/utils/static.py
+++ b/onedrivecmd/utils/static.py
@@ -7,7 +7,7 @@
 
 global VER, redirect_uri, client_secret, client_id, api_base_url, scopes, discovery_uri, auth_server_url, auth_token_url
 
-VER = 'OnedriveCMD V0.1.7'
+VER = 'OnedriveCMD V0.1.7.1-dev'
 
 # If you are not sure whether this is safe,
 # you can register your own APP and use your own URL.

--- a/onedrivecmd/utils/static.py
+++ b/onedrivecmd/utils/static.py
@@ -7,7 +7,7 @@
 
 global VER, redirect_uri, client_secret, client_id, api_base_url, scopes, discovery_uri, auth_server_url, auth_token_url
 
-VER = 'OnedriveCMD V0.1.6.2-dev'
+VER = 'OnedriveCMD V0.1.7'
 
 # If you are not sure whether this is safe,
 # you can register your own APP and use your own URL.

--- a/onedrivecmd/utils/uploader.py
+++ b/onedrivecmd/utils/uploader.py
@@ -7,6 +7,7 @@
 import json
 from progress.bar import Bar
 import requests
+from collections import OrderedDict
 
 try:
     from static import *
@@ -62,9 +63,9 @@ def upload_self(api_base_url = '', token = '', source_file = '', dest_path = '',
     if not dest_path.endswith('/'):
         dest_path += '/'
 
-    # Prepare API call
+    # Prepare API call (note: info_json must be ordered else error 'Annotations must be specified before other elements in a JSON object' will be reported.)
     dest_path = path_to_remote_path(dest_path) + '/' + path_to_name(source_file)
-    info_json = json.dumps({'item': {'@name.conflictBehavior': 'rename', 'name': path_to_name(source_file)}})
+    info_json = json.dumps({'item': OrderedDict([('@name.conflictBehavior', 'rename'), ('name', path_to_name(source_file))])})
 
     api_url = api_base_url + 'drive/root:{dest_path}:/upload.createSession'.format(dest_path = dest_path)
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.1.6.2-dev',
+    version='0.1.7',
 
     description='A command line client for Onedrive.',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.1.7',
+    version='0.1.7.1-dev',
 
     description='A command line client for Onedrive.',
     long_description=long_description,


### PR DESCRIPTION
**新版本 0.1.7**, 改动:

1. 添加了实验性的失败时重传功能. 对于不带 `-hack` 的上传功能来说, 可以只重传当前分片, 大大地提高了效率. 目前的重试的次数限制为五次. 

![Snipaste_2019-03-18_16-03-13](https://user-images.githubusercontent.com/41772157/54580534-80761f80-4a43-11e9-8502-668be6cd8db9.png)

![Snipaste_2019-03-19_11-55-45](https://user-images.githubusercontent.com/41772157/54580417-f037da80-4a42-11e9-8eef-054cda0d7c90.png)

2. `put` 总是能够上传文件夹了! 因此为 `-hack` 新写了一个函数 `upload_self_hack(...)` 用来实现递归. 

![Snipaste_2019-03-19_12-17-13](https://user-images.githubusercontent.com/41772157/54580481-3e4cde00-4a43-11e9-8dc2-bb1509dbcaf3.png)

3. 修复 bug: 这个 bug 曾导致 `put` 无法上传空文件. 

4. 修复 bug: 这个 bug 曾导致 `put -hack` 无法上传任何文件. 

5. 修复 bug: 这个 bug 曾导致, 当上传的远程文件夹是根目录 `/` 时, 发送的请求实际是 `//`.

5. 修改了 `list` 的一个显示细节.

6. 更新了 README.md. 
