### PR TITLE
Add 996.icu | 加入996.ICU

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 onedrivecmd
 =======
 
+<a href="https://996.icu"><img src="https://img.shields.io/badge/link-996.icu-red.svg"></a>
+
 A command line client for Onedrive(including Office 365 and Business).
 
 Based on [onedrive-sdk-python](https://github.com/OneDrive/onedrive-sdk-python) , with lots of modifications.


### PR DESCRIPTION
Proposal：加入996.icu

## Q&A

1. 为什么作为一线工作者要支持996.ICU？

因为在无监管的环境下，整个行业会向无底线推进，所谓“race to the bottom”。在这种博弈中没有任何人会得到好处。

您有可能年富力强。您会永远年富力强吗？您觉得996会帮助您避免工程师的中年危机吗？您觉得996证明了您的技术能力吗？您觉得主动支持公司的违法行为这一做法证明了您的职业操守吗？您觉得在35岁后还有精力996吗？您觉得现在996会帮助您在10年后安全落地吗？

Play stupid game, win stupid prizes.

软件开发是从需求中寻找逻辑，将其转换为代码的工作。这种工作天生包括了大量的创造性，需要您投入大量的思考。长时间的工时投入对创造不会有什么帮助。

不要自降身价，认为自己是“流水线工人“。这对您的职业发展有害无益。

2. 为什么作为中层管理要支持996.ICU？

因为长时间压榨员工对绩效有反作用。

经常性延长工时只能代表您这位管理者的计划能力低下，或者代表您，作为管理者，在公司没有话语权。这对您的专业能力是一种侮辱。

专业的管理者有能力对进度、规划和预期进行合理的管理，包括对上、对下、对外管理。

请向公司证明您的专业能力。

3. 为什么作为高层管理要支持996.ICU？

《人月神话》的例子并不过时：软件开发不是体力劳动。软件开发是工程师利用代码将逻辑定义为操作的行为，与工时没有正相关性。所以您会对一些高级程序员开出数倍工资：因为好的软件工程师是可以以一顶百的。

软件工程师（Software Engineer）与其他工程师（Engineer）的最重大区别在于，软件工程师的劳动资料和劳动者都是工程师本身，而劳动对象很便宜。

直观的看，软件工程师每日所需的硬件劳动资料，平均到个人，以2年贬值（会计上可以做到8年）计算，不超过10000 USD。这个价格比纯流水线普工高一些，但是甚至和清洁工比都不算高——因为主要的成本是工程师的开发能力。软件工程的劳动对象便宜的令人发指——世界500强公司的年服务器费用也不到100M USD，这个价格在制造业肯定是盖不起厂房了。

软件工程师更类似于手工业者：这种劳动关系在未来很难出现变化，除非我们研究出如何让AI自己写代码。（当然到时候我们又需要更多的工程师教AI写代码，这里按下不表。）

称职的软件工程师可以从您的需求中提炼出逻辑，并将其转换为代码。如果您自己也不知道您需要什么，那您不是称职的管理者。

如果您认为加长工时可以解决问题，那您已经默认公司的软件开发不需要创造，进而可以推出您的开发部门是成本部门。想想，您是不是给自己的职业发展挖了个坑？

## 结语

996是一种小农的粗放管理办法，对个人、公司都有害无益。

不要996：事实证明996不能解决问题。