### PR TITLE
Fix SyntaxWarning in Python 3.8

### DIFF
--- a/onedrivecmd/utils/actions.py
+++ b/onedrivecmd/utils/actions.py
@@ -164,7 +164,7 @@ def do_get(client, args):
     """
     if not args.rest[-1].startswith('od:/'):
         local_dir=args.rest[-1]
-        if local_dir.endswith("/") and local_dir is not "/":
+        if local_dir.endswith("/") and local_dir != "/":
             local_dir=local_dir[:-1]
         args.rest=args.rest[:-1]
     else:
@@ -394,7 +394,7 @@ def do_delete(client, args):
             req = requests.delete(client.base_url + '/drive/items/{id}'.format(id = f.id),
                                   headers = {'Authorization': 'bearer {access_token}'.format(
                                       access_token = get_access_token(client)), })
-            if req.status_code is not 204:
+            if req.status_code != 204:
                 print_error("Request", str(req.status_code)+" "+req.json()['error']['message'])
                 return None
 

--- a/onedrivecmd/utils/downloader.py
+++ b/onedrivecmd/utils/downloader.py
@@ -34,7 +34,7 @@ def download_self(client, remote_path="", local_dir="", chunksize = 10247680, ur
     if not local_dir.endswith("/"):
         local_dir+="/"
 
-    if remote_path.endswith("/") and remote_path is not "/":
+    if remote_path.endswith("/") and remote_path != "/":
         remote_path=remote_path[:-1]
 
     item=get_remote_item(client, path=remote_path)

--- a/onedrivecmd/utils/helper_item.py
+++ b/onedrivecmd/utils/helper_item.py
@@ -28,7 +28,7 @@ def get_remote_item(client, path = '', id = ''):
     try:
         if path != '':  # check path
             path = od_path_to_api_path(path)
-            if path.endswith("/") and path is not "/":
+            if path.endswith("/") and path != "/":
                 path=path[:-1]
             f = client.item(drive = 'me', path = path).get()
         elif id != '':  # check id
@@ -48,15 +48,15 @@ def get_remote_folder_children(client, path="", id=""):
     work with path or id.
     """
     try:
-        if path is not "":
+        if path != "":
             path = od_path_api_path(path)
             #f = client.item(drive="me", path=path).get()
             #if not f.folder:
             #    return None
-            if path.endswith("/") and path is not "/":
+            if path.endswith("/") and path != "/":
                 path=path[:-1]
             f = client.item(drive="me", path=path).children.get()
-        elif id is not "":
+        elif id != "":
             #f = client.item(drive="me", id=id).get()
             #if not f.folder:
             #    return None

--- a/onedrivecmd/utils/helper_print.py
+++ b/onedrivecmd/utils/helper_print.py
@@ -14,9 +14,9 @@ def print_error(error_type="",note=""):
     will be printed in red.
     """
 
-    if error_type is "":
+    if error_type == "":
         print("\033[31m"+note+"\033[0m")
-    elif note is "":
+    elif note == "":
         print("\033[31m"+error_type+" error.\033[0m")
     else:
         print("\033[31m"+error_type+" error:\033[0m "+note)

--- a/onedrivecmd/utils/uploader.py
+++ b/onedrivecmd/utils/uploader.py
@@ -67,7 +67,7 @@ def upload_self(client, source_file = '', dest_path = '', chunksize = 10247680):
     if not dest_path.endswith('/'):
         dest_path += '/'
 
-    if source_file.endswith('/') and source_file is not "/":
+    if source_file.endswith('/') and source_file != "/":
         source_file=source_file[:-1]
 
     # check if it's a file


### PR DESCRIPTION
https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-python-behavior

The compiler now produces a `SyntaxWarning` when identity checks (`is` and `is not`) are used with certain types of literals (e.g. strings, numbers). These can often work by accident in CPython, but are not guaranteed by the language spec. The warning advises users to use equality tests (`==` and `!=`) instead.

修复在 Python 3.8 环境下，在比较字面量时使用 `is` 或者 `is not` 报 `SyntaxWarning` 的警告